### PR TITLE
mcp: add healthcheck and fix some other miscellaneous bugs

### DIFF
--- a/mcp/Cargo.lock
+++ b/mcp/Cargo.lock
@@ -21,6 +21,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +251,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +298,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "core-foundation"
@@ -456,6 +552,12 @@ dependencies = [
  "r-efi 6.0.0",
  "rand_core 0.10.1",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hmac-sha256"
@@ -711,6 +813,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,6 +960,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
@@ -1345,6 +1459,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,12 +1524,14 @@ dependencies = [
  "anyhow",
  "axum",
  "base64 0.22.1",
+ "clap",
  "http 1.4.2",
  "js_option",
  "rmcp",
  "schemars",
  "serde",
  "serde_json",
+ "strum",
  "svix",
  "tokio",
  "tracing",
@@ -1654,6 +1791,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -8,12 +8,14 @@ description = "Svix MCP servers: app portal (sending webhooks) and ingest (recei
 anyhow = "1"
 axum = "0.8"
 base64 = "0.22"
+clap = { version = "4.6.3", features = ["derive", "env"] }
 http = "1"
 js_option = "0.1"
 rmcp = { version = "1.8", features = ["server", "transport-io", "macros", "schemars", "transport-streamable-http-server"] }
 schemars = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+strum = { version = "0.28.0", features = ["derive"] }
 svix = "1.96"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "signal"] }
 tracing = "0.1"

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -40,9 +40,8 @@ ENV MCP_TRANSPORT=http \
     MCP_BIND_ADDR=0.0.0.0:8080
 EXPOSE 8080
 
-# Although this is going to return 401, it's fine to see if the server is up
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD curl -sS -o /dev/null http://127.0.0.1:8080/ingest || exit 1
+    CMD curl -sS -o /dev/null http://127.0.0.1:8080/health || exit 1
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["/usr/local/bin/svix-mcp"]

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -19,6 +19,7 @@ use axum::{
     response::{IntoResponse, Response},
     routing::get,
 };
+use clap::Parser;
 use http::{StatusCode, header};
 use rmcp::{
     ServiceExt,
@@ -31,8 +32,6 @@ use serde::Serialize;
 use svix::api::Svix;
 
 use crate::{app_portal::AppPortalServer, common::svix_options, ingest::IngestServer};
-
-use clap::Parser;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumString, strum::Display)]
 #[strum(serialize_all = "kebab-case")]

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -14,8 +14,10 @@ mod ingest;
 
 use anyhow::Context;
 use axum::{
+    Json,
     middleware::{Next, from_fn},
     response::{IntoResponse, Response},
+    routing::get,
 };
 use http::{StatusCode, header};
 use rmcp::{
@@ -25,12 +27,30 @@ use rmcp::{
         streamable_http_server::{StreamableHttpService, session::local::LocalSessionManager},
     },
 };
+use serde::Serialize;
 use svix::api::Svix;
 
 use crate::{app_portal::AppPortalServer, common::svix_options, ingest::IngestServer};
 
+use clap::Parser;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumString, strum::Display)]
+#[strum(serialize_all = "kebab-case")]
+enum McpTransport {
+    Http,
+    Stdio,
+}
+
+#[derive(Parser)]
+struct Args {
+    #[clap(long, env = "MCP_TRANSPORT", default_value_t = McpTransport::Stdio)]
+    transport: McpTransport,
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+
     // Logs must go to stderr; stdout is the stdio MCP stream.
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -40,10 +60,9 @@ async fn main() -> anyhow::Result<()> {
         .with_ansi(false)
         .init();
 
-    match std::env::var("MCP_TRANSPORT").as_deref() {
-        Ok("http") => run_http().await,
-        Ok("stdio") | Err(_) => run_stdio().await,
-        Ok(other) => anyhow::bail!("unknown MCP_TRANSPORT {other:?}; expected `stdio` or `http`"),
+    match args.transport {
+        McpTransport::Http => run_http().await,
+        McpTransport::Stdio => run_stdio().await,
     }
 }
 
@@ -83,6 +102,39 @@ async fn run_stdio() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[derive(Debug, Serialize)]
+struct HealthResponse {
+    ok: bool,
+}
+
+async fn healthcheck() -> Json<HealthResponse> {
+    Json(HealthResponse { ok: true })
+}
+
+async fn wait_for_shutdown() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("Failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let sigterm = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("Failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let sigterm = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = sigterm => {},
+    }
+}
+
 /// http serves both servers; the path picks one. Each authenticates entirely
 /// from the bearer token, so the app portal's `{app_id}` segment is only there
 /// to keep one user's MCP clients for several applications from colliding.
@@ -107,23 +159,26 @@ async fn run_http() -> anyhow::Result<()> {
         Default::default(),
     );
 
-    let app = axum::Router::new()
+    let authenticated = axum::Router::new()
         .nest_service("/app/{app_id}", app_portal)
         .nest_service("/ingest", ingest)
         .layer(from_fn(require_authorization));
 
+    let unauthenticated = axum::Router::new().route("/health", get(healthcheck));
+
+    let app = authenticated.merge(unauthenticated);
+
     let listener = tokio::net::TcpListener::bind(&addr)
         .await
         .with_context(|| format!("failed to bind {addr}"))?;
+    let bound = listener.local_addr()?;
     tracing::info!(
-        "starting svix mcp over HTTP: app portal on http://{addr}/app/{{app_id}}, ingest on \
-         http://{addr}/ingest"
+        "starting svix mcp over HTTP: app portal on http://{bound}/app/{{app_id}}, ingest on \
+         http://{bound}/ingest"
     );
 
     axum::serve(listener, app)
-        .with_graceful_shutdown(async {
-            let _ = tokio::signal::ctrl_c().await;
-        })
+        .with_graceful_shutdown(wait_for_shutdown())
         .await
         .context("HTTP server error")?;
     Ok(())


### PR DESCRIPTION
Changes:

 - adds an unauthenticated healthcheck route that returns 200
 - adds basic `--help`
 - catches SIGTERM in addition to SIGINT to shut down
 - logs correct address at startup